### PR TITLE
changes for use against Codeplex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tests/db/dumps
 tests/db/cache
 tests/db/wcs
 tests/auto/work
+src/rsvndump

--- a/src/dump.c
+++ b/src/dump.c
@@ -363,7 +363,7 @@ char dump(session_t *session, dump_options_t *opts)
 		/* Jump to local revision and fill the path hash for previous revisions */
 		local_rev = 0;
 		while ((local_rev < (long int)logs.size) && (((log_revision_t *)logs.elements)[local_rev].revision < opts->start)) {
-			DEBUG_MSG("Filling path hash for rev %ld of %ld\n", local_rev, (long int)logs.size);
+			DEBUG_MSG("Filling path hash for rev %ld (%ld) of %ld\n", local_rev, ((log_revision_t *)logs.elements)[local_rev].revision, (long int)logs.size);
 			svn_revnum_t phrev = ((opts->flags & DF_KEEP_REVNUMS) ? ((log_revision_t *)logs.elements)[local_rev].revision : local_rev);
 			if (path_hash_commit(session, (log_revision_t *)logs.elements + local_rev, phrev)) {
 				return 1;

--- a/src/dump.c
+++ b/src/dump.c
@@ -355,7 +355,7 @@ char dump(session_t *session, dump_options_t *opts)
 	 * prior to dumping.
 	 */
 	if (start_mid) {
-		if (log_fetch_all(session, 0, opts->end, &logs, opts->verbosity, opts->log_window_size)) {
+		if (log_fetch_all(session, opts->first, opts->end, &logs, opts->verbosity, opts->log_window_size)) {
 			return 1;
 		}
 		logs_fetched = 1;

--- a/src/dump.c
+++ b/src/dump.c
@@ -442,7 +442,9 @@ char dump(session_t *session, dump_options_t *opts)
 		if ((opts->flags & DF_KEEP_REVNUMS) && !(opts->flags & DF_DRY_RUN)) {
 			/* Padd with empty revisions if neccessary */
 			while (local_rev < ((log_revision_t *)logs.elements)[list_idx].revision) {
-				dump_padding_revision(revpool, local_rev);
+				if (!(opts->flags & DF_OMIT_PADDING_REVISIONS)) {
+					dump_padding_revision(revpool, local_rev);
+				}
 				if (opts->verbosity == 0) {
 					fprintf(stderr, _("* Padded revision %ld.\n"), local_rev);
 				} else if (opts->verbosity > 0) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -355,7 +355,7 @@ char dump(session_t *session, dump_options_t *opts)
 	 * prior to dumping.
 	 */
 	if (start_mid) {
-		if (log_fetch_all(session, 0, opts->end, &logs, opts->verbosity)) {
+		if (log_fetch_all(session, 0, opts->end, &logs, opts->verbosity, opts->log_window_size)) {
 			return 1;
 		}
 		logs_fetched = 1;

--- a/src/dump.c
+++ b/src/dump.c
@@ -365,7 +365,7 @@ char dump(session_t *session, dump_options_t *opts)
 		while ((local_rev < (long int)logs.size) && (((log_revision_t *)logs.elements)[local_rev].revision < opts->start)) {
 			DEBUG_MSG("Filling path hash for rev %ld (%ld) of %ld\n", local_rev, ((log_revision_t *)logs.elements)[local_rev].revision, (long int)logs.size);
 			svn_revnum_t phrev = ((opts->flags & DF_KEEP_REVNUMS) ? ((log_revision_t *)logs.elements)[local_rev].revision : local_rev);
-			if (path_hash_commit(session, (log_revision_t *)logs.elements + local_rev, phrev)) {
+			if (path_hash_commit(session, (log_revision_t *)logs.elements, local_rev, phrev, (opts->flags & DF_ADJUST_MISSING_REVNUMS))) {
 				return 1;
 			}
 			++local_rev;
@@ -503,7 +503,7 @@ char dump(session_t *session, dump_options_t *opts)
 
 		/* Insert revision into path_hash */
 		if (!(opts->flags & DF_DRY_RUN) || strlen(session->prefix) != 0) {
-			if (path_hash_commit(session, (log_revision_t *)logs.elements + list_idx, local_rev)) {
+			if (path_hash_commit(session, (log_revision_t *)logs.elements, list_idx, local_rev, (opts->flags & DF_ADJUST_MISSING_REVNUMS))) {
 				ret = 1;
 				break;
 			}

--- a/src/dump.c
+++ b/src/dump.c
@@ -363,6 +363,7 @@ char dump(session_t *session, dump_options_t *opts)
 		/* Jump to local revision and fill the path hash for previous revisions */
 		local_rev = 0;
 		while ((local_rev < (long int)logs.size) && (((log_revision_t *)logs.elements)[local_rev].revision < opts->start)) {
+			DEBUG_MSG("Filling path hash for rev %ld of %ld\n", local_rev, (long int)logs.size);
 			svn_revnum_t phrev = ((opts->flags & DF_KEEP_REVNUMS) ? ((log_revision_t *)logs.elements)[local_rev].revision : local_rev);
 			if (path_hash_commit(session, (log_revision_t *)logs.elements + local_rev, phrev)) {
 				return 1;

--- a/src/dump.h
+++ b/src/dump.h
@@ -39,7 +39,8 @@ enum dump_flags {
 	DF_KEEP_REVNUMS = 0x02,
 	DF_INCREMENTAL = 0x04,
 	DF_DRY_RUN = 0x08,
-	DF_NO_INCREMENTAL_HEADER = 0x10
+	DF_NO_INCREMENTAL_HEADER = 0x10,
+	DF_ADJUST_MISSING_REVNUMS = 0x20
 };
 
 /* Data structure to bundle information related to the dumping process */

--- a/src/dump.h
+++ b/src/dump.h
@@ -40,7 +40,8 @@ enum dump_flags {
 	DF_INCREMENTAL = 0x04,
 	DF_DRY_RUN = 0x08,
 	DF_NO_INCREMENTAL_HEADER = 0x10,
-	DF_ADJUST_MISSING_REVNUMS = 0x20
+	DF_ADJUST_MISSING_REVNUMS = 0x20,
+	DF_OMIT_PADDING_REVISIONS = 0x40
 };
 
 /* Data structure to bundle information related to the dumping process */

--- a/src/dump.h
+++ b/src/dump.h
@@ -51,6 +51,7 @@ typedef struct {
 	int           verbosity;
 	int           flags;
 	int           dump_format;
+	int           log_window_size;
 } dump_options_t;
 
 

--- a/src/dump.h
+++ b/src/dump.h
@@ -46,6 +46,7 @@ enum dump_flags {
 typedef struct {
 	char          *temp_dir;
 	char          *prefix;
+	svn_revnum_t  first;
 	svn_revnum_t  start;
 	svn_revnum_t  end;
 	int           verbosity;

--- a/src/log.c
+++ b/src/log.c
@@ -239,11 +239,16 @@ char log_fetch_all(session_t *session, svn_revnum_t start, svn_revnum_t end, lis
 		window_size = end - start + 1;
 	}
 	for (i = start; i <= end; i += window_size) {
-		if (verbosity > 0) {
-			fprintf(stderr, _("Fetching logs %ld to %ld of %ld... "), i, i + window_size - 1, end);
+		svn_revnum_t last = i + window_size - 1;
+		if (last > end) {
+			last = end;
 		}
 
-		if ((err = svn_ra_get_log(session->ra, paths, i, i + window_size - 1, 0, TRUE, FALSE, log_receiver_list, &baton, pool))) {
+		if (verbosity > 0) {
+			fprintf(stderr, _("Fetching logs %ld to %ld of %ld... "), i, last, end);
+		}
+
+		if ((err = svn_ra_get_log(session->ra, paths, i, last, 0, TRUE, FALSE, log_receiver_list, &baton, pool))) {
 			if (verbosity > 0) {
 				fprintf(stderr, "\n");
 			}

--- a/src/log.c
+++ b/src/log.c
@@ -163,7 +163,7 @@ char log_get_range(session_t *session, svn_revnum_t *start, svn_revnum_t *end, i
 	baton.pool = subpool;
 
 	if (verbosity > 0) {
-		fprintf(stderr, _("Determining start end end revision... "));
+		fprintf(stderr, _("Determining start and end revision... "));
 	}
 	if ((err = svn_ra_get_log(session->ra, paths, *start, *end, 0, FALSE, TRUE, log_receiver_list, &baton, subpool))) {
 		if (verbosity > 0) {

--- a/src/log.h
+++ b/src/log.h
@@ -51,7 +51,7 @@ extern char log_get_range(session_t *session, svn_revnum_t *start, svn_revnum_t 
 extern char log_fetch_single(session_t *session, svn_revnum_t rev, svn_revnum_t end, log_revision_t *log, apr_pool_t *pool);
 
 /* Fetches all revision logs for a given revision range */
-extern char log_fetch_all(session_t *session, svn_revnum_t start, svn_revnum_t end, list_t *list, int verbosity);
+extern char log_fetch_all(session_t *session, svn_revnum_t start, svn_revnum_t end, list_t *list, int verbosity, int window_size);
 
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -138,7 +138,7 @@ static char parse_revnum(char *str, svn_revnum_t *start, svn_revnum_t *end)
 	return 1;
 }
 
-static char parse_num(char *str, int *num)
+static char parse_num(char *str, svn_revnum_t *num)
 {
 	char eos;
 	if (sscanf(str, "%ld%c", num, &eos) == 1) {

--- a/src/main.c
+++ b/src/main.c
@@ -80,6 +80,8 @@ static void print_usage()
 	printf(_("    --keep-revnums            keep the dumped revision numbers in sync with\n" \
 	         "                              the repository by using empty revisions for\n" \
 	         "                              padding\n"));
+	printf(_("    --adjust-missing-revnums  if copying from a missing revision, search\n" \
+	         "                              backwards for the previous revision and use it"));
 	printf(_("    --no-incremental-header   don't print the dumpfile header when dumping\n" \
 	         "                              with --incremental and not starting at\n" \
 	         "                              revision 0\n"));
@@ -211,6 +213,10 @@ int main(int argc, char **argv)
 			session.flags |= SF_NO_AUTH_CACHE;
 		} else if (!strcmp(argv[i], "--non-interactive")) {
 			session.flags |= SF_NON_INTERACTIVE;
+		} else if (!strcmp(argv[i], "--adjust-missing-revnums")) {
+			opts.flags |= DF_ADJUST_MISSING_REVNUMS;
+			/* implies the following */
+			opts.flags |= DF_KEEP_REVNUMS;
 		} else if (!strcmp(argv[i], "--keep-revnums")) {
 			opts.flags |= DF_KEEP_REVNUMS;
 		} else if (!strcmp(argv[i], "--no-incremental-header")) {

--- a/src/main.c
+++ b/src/main.c
@@ -80,9 +80,9 @@ static void print_usage()
 	printf(_("    --keep-revnums            keep the dumped revision numbers in sync with\n" \
 	         "                              the repository by using empty revisions for\n" \
 	         "                              padding\n"));
-	printf(_("    --no-incremental-header   don't print the dumpfile header when dumping\n"));
-	printf(_("                              with --incremental and not starting at\n"));
-	printf(_("                              revision 0\n"));
+	printf(_("    --no-incremental-header   don't print the dumpfile header when dumping\n" \
+	         "                              with --incremental and not starting at\n" \
+	         "                              revision 0\n"));
 	printf(_("    --log-window-size         when retrieving the log for a large number of\n" \
 	         "                              revisions, retrieve the specified number at a\n" \
 	         "                              time to avoid timeouts\n"));

--- a/src/main.c
+++ b/src/main.c
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
 				dump_options_free(&opts);
 				return EXIT_FAILURE;
 			}
-		} else if (i+1 < argc && (!strcmp(argv[i], "--first"))) {
+		} else if (i+1 < argc && (!strcmp(argv[i], "--first-rev"))) {
 			if (parse_num(argv[++i], &opts.first)) {
 				fprintf(stderr, _("ERROR: invalid revision number '%s'.\n"), argv[i]);
 				session_free(&session);

--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,8 @@ static void print_usage()
 	printf(_("    --log-window-size         when retrieving the log for a large number of\n" \
 	         "                              revisions, retrieve the specified number at a\n" \
 	         "                              time to avoid timeouts\n"));
+	printf(_("    --first-rev               start repository at the given revision instead\n" \
+	         "                              of 0.\n"));
 	printf("\n");
 	printf(_("Report bugs to <%s>\n"), PACKAGE_BUGREPORT);
 }
@@ -219,6 +221,13 @@ int main(int argc, char **argv)
 			opts.flags |= DF_INCREMENTAL;
 		} else if (i+1 < argc && (!strcmp(argv[i], "--log-window-size"))) {
 			if (parse_num(argv[++i], &opts.log_window_size)) {
+				fprintf(stderr, _("ERROR: invalid revision number '%s'.\n"), argv[i]);
+				session_free(&session);
+				dump_options_free(&opts);
+				return EXIT_FAILURE;
+			}
+		} else if (i+1 < argc && (!strcmp(argv[i], "--first"))) {
+			if (parse_num(argv[++i], &opts.first)) {
 				fprintf(stderr, _("ERROR: invalid revision number '%s'.\n"), argv[i]);
 				session_free(&session);
 				dump_options_free(&opts);

--- a/src/main.c
+++ b/src/main.c
@@ -80,6 +80,9 @@ static void print_usage()
 	printf(_("    --keep-revnums            keep the dumped revision numbers in sync with\n" \
 	         "                              the repository by using empty revisions for\n" \
 	         "                              padding\n"));
+	printf(_("    --omit-padding-revs       with --keep-revnums, don't add padding revisions\n" \
+	         "                              but still skip revision numbers (leaving them out\n" \
+	         "                              of sync)\n"));
 	printf(_("    --adjust-missing-revnums  if copying from a missing revision, search\n" \
 	         "                              backwards for the previous revision and use it"));
 	printf(_("    --no-incremental-header   don't print the dumpfile header when dumping\n" \
@@ -215,10 +218,13 @@ int main(int argc, char **argv)
 			session.flags |= SF_NON_INTERACTIVE;
 		} else if (!strcmp(argv[i], "--adjust-missing-revnums")) {
 			opts.flags |= DF_ADJUST_MISSING_REVNUMS;
-			/* implies the following option, because the dump doesn't work if there are missing revs */
+			/* TODO: implies the following option, because the dump doesn't work if there are missing revs */
 			opts.flags |= DF_KEEP_REVNUMS;
 		} else if (!strcmp(argv[i], "--keep-revnums")) {
 			opts.flags |= DF_KEEP_REVNUMS;
+		} else if (!strcmp(argv[i], "--omit-padding-revs")) {
+			/* TODO: this is primarily to workaround the bug in --adjust-missing-revnums above */
+			opts.flags |= DF_OMIT_PADDING_REVISIONS;
 		} else if (!strcmp(argv[i], "--no-incremental-header")) {
 			opts.flags |= DF_NO_INCREMENTAL_HEADER;
 		} else if (!strcmp(argv[i], "--deltas")) {

--- a/src/main.c
+++ b/src/main.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
 			session.flags |= SF_NON_INTERACTIVE;
 		} else if (!strcmp(argv[i], "--adjust-missing-revnums")) {
 			opts.flags |= DF_ADJUST_MISSING_REVNUMS;
-			/* implies the following */
+			/* implies the following option, because the dump doesn't work if there are missing revs */
 			opts.flags |= DF_KEEP_REVNUMS;
 		} else if (!strcmp(argv[i], "--keep-revnums")) {
 			opts.flags |= DF_KEEP_REVNUMS;

--- a/src/main.c
+++ b/src/main.c
@@ -84,7 +84,7 @@ static void print_usage()
 	         "                              but still skip revision numbers (leaving them out\n" \
 	         "                              of sync)\n"));
 	printf(_("    --adjust-missing-revnums  if copying from a missing revision, search\n" \
-	         "                              backwards for the previous revision and use it"));
+	         "                              backwards for the previous revision and use it\n"));
 	printf(_("    --no-incremental-header   don't print the dumpfile header when dumping\n" \
 	         "                              with --incremental and not starting at\n" \
 	         "                              revision 0\n"));

--- a/src/path_hash.h
+++ b/src/path_hash.h
@@ -38,7 +38,7 @@ extern void path_hash_initialize(const char *session_prefix, const char *temp_di
 extern void path_hash_add_path(const char *path);
 
 /* Adds a new revision to the path hash */
-extern char path_hash_commit(session_t *session, log_revision_t *log, svn_revnum_t revnum);
+extern char path_hash_commit(session_t *session, log_revision_t *log_full, int log_start, svn_revnum_t revnum, char adjust_missing_revnums);
 
 /* Checks the parent relation of two paths at a given revision */
 extern char path_hash_check_parent(const char *parent, const char *child, svn_revnum_t revision, apr_pool_t *pool);


### PR DESCRIPTION
Hi,

I've implemented a series of changes to successfully dump a project from Codeplex. They use "SVNBridge", which doesn't work with svnsync, making rsvndump a great option. 

In summary, the changes are to:
- improve options for working with repositories with missing revision numbers
- changes to help deal with timeouts better (by sending many requests for log fetching instead of one long one, and by allowing resuming from a more recent revision to avoid rebuilding the path hash)
- additional logging.

I hope you find them useful
