### PR TITLE
configure.ac: Support the AR variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ fi
 # Checks for programs.
 AC_PROG_INSTALL
 AC_PROG_CC
+AM_PROG_AR
 AC_PROG_RANLIB
 if test "$USE_MAN" = "yes"; then
 	RSVN_CHECK_MAN_PROGS


### PR DESCRIPTION
The build system of rsvndump is currently hard-coding command `ar` rather than respecting variable `AR` to support alternatives to `ar`. This turned up at https://bugs.gentoo.org/724252 and is part of bigger picture https://bugs.gentoo.org/243502 . Please consider this pull request to ship the fix to all users.

PS: https://stackoverflow.com/questions/47074736/autoconf-uses-wrong-ar-on-os-x may be of interest for more context.