### PR TITLE
configure: Fix version extractions for multi-digit versions e.g. with asciidoc 10.1.1

### DIFF
--- a/m4/rsvndump_conf.m4
+++ b/m4/rsvndump_conf.m4
@@ -73,9 +73,9 @@ AC_DEFUN([RSVN_CHECK_MAN_PROGS], [
 		AC_MSG_ERROR([Asciidoc could not be located in your \$PATH])
 	fi
 	ver_info=`$ASCIIDOC --version`
-	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\1/'`
-	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\2/'`
-	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\3/'`
+	ver_maj=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\1/'`
+	ver_min=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\2/'`
+	ver_rev=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\3/'`
 	prog_version_ok=no
 	if test $ver_maj -gt 8 -o \( $ver_maj -eq 8 -a $ver_min -ge 4 \); then
 		prog_version_ok=yes
@@ -91,9 +91,9 @@ AC_DEFUN([RSVN_CHECK_MAN_PROGS], [
 		AC_MSG_ERROR([xmlto could not be located in your \$PATH])
 	fi
 	ver_info=`$XMLTO --version`
-	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\1/'`
-	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\2/'`
-	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\3/'`
+	ver_maj=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\1/'`
+	ver_min=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\2/'`
+	ver_rev=`echo $ver_info | sed -E 's/^.* ([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+).*$/\3/'`
 	prog_version_ok="yes"
 	if test $ver_maj -lt 0; then
 		prog_version_ok="no"

--- a/m4/rsvndump_conf.m4
+++ b/m4/rsvndump_conf.m4
@@ -73,9 +73,9 @@ AC_DEFUN([RSVN_CHECK_MAN_PROGS], [
 		AC_MSG_ERROR([Asciidoc could not be located in your \$PATH])
 	fi
 	ver_info=`$ASCIIDOC --version`
-	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\1/'`
-	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\2/'`
-	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\3/'`
+	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\1/'`
+	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\2/'`
+	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\3/'`
 	prog_version_ok=no
 	if test $ver_maj -gt 8 -o \( $ver_maj -eq 8 -a $ver_min -ge 4 \); then
 		prog_version_ok=yes
@@ -91,9 +91,9 @@ AC_DEFUN([RSVN_CHECK_MAN_PROGS], [
 		AC_MSG_ERROR([xmlto could not be located in your \$PATH])
 	fi
 	ver_info=`$XMLTO --version`
-	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\1/'`
-	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\2/'`
-	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\)*\.\([[0-9]]\)*\.\([[0-9]]*\).*$/\3/'`
+	ver_maj=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\1/'`
+	ver_min=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\2/'`
+	ver_rev=`echo $ver_info | sed 's/^.* \([[0-9]]\+\)\.\([[0-9]]\+\)\.\([[0-9]]\+\).*$/\3/'`
 	prog_version_ok="yes"
 	if test $ver_maj -lt 0; then
 		prog_version_ok="no"


### PR DESCRIPTION
Hi @jgehring,

a fellow Gentoo developer filed a bug report that [rsvndump currently rejects asciidoc 10 at configure time](https://bugs.gentoo.org/832801) despite the effort at #6 which I confirm:

```console
# ./configure --enable-man |& fgrep -i asciidoc
checking for asciidoc... /usr/bin/asciidoc
configure: error: Asciidoc >= 8.4 is needed. Please upgrade your installation

# asciidoc --version
asciidoc 10.1.1
```

It turns out that the version extractor only pulled the first digit(!) into the regex capture because of where the closing braces were placed. It would be great if you could review this patch shortly, so I can apply a fix downstream that is in line with you upstream.

Thanks in advance, best, Sebastian :beers: 
