### PR TITLE
configure.ac: Resolve use of deprecated AC_CONFIG_HEADER (singular) (fixes #12)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE()
 AC_PREFIX_DEFAULT([/usr/local])
 test $prefix = NONE && prefix=/usr/local
 
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_LIBOBJ_DIR([lib])
 
 sinclude(m4/find_apr.m4)


### PR DESCRIPTION
Fixes #12 (or [what's left of it](https://github.com/jgehring/rsvndump/issues/12#issuecomment-1245424185))